### PR TITLE
Fix/tao 3504 pci provider requirejs

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'QTI Portable Custom Interaction',
     'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '2.0.1',
+    'version' => '2.0.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -138,6 +138,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('1.6.2');
         }
 
-        $this->skip('1.6.2', '2.0.1');
+        $this->skip('1.6.2', '2.0.2');
     }
 }

--- a/views/js/pciProvider.js
+++ b/views/js/pciProvider.js
@@ -16,7 +16,7 @@
  * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
  *
  */
-define(['jquery', 'helpers', 'core/promise'], function($, helpers, Promise){
+define('qtiItemPci/pciProvider', ['jquery', 'helpers', 'core/promise'], function($, helpers, Promise){
     'use strict';
     
     var _serverUrl = helpers._url('load', 'PciLoader', 'qtiItemPci');


### PR DESCRIPTION
Related to https://github.com/oat-sa/extension-tao-itemqti/pull/936 and represents half of the fix.

Safari requires the pciProvider module to be named.
Naming the pciProvider is alright as it is not to be bundled but be called via the pci provider registration system: the registration is done here https://github.com/oat-sa/extension-tao-itemqti-pci/blob/master/scripts/install/RegisterClientProvider.php and the call is  done here https://github.com/oat-sa/extension-tao-itemqti/blob/master/views/js/portableElementRegistry/ciRegistry.js#L27-L29