### PR TITLE
Fix/tao 4473 disable enable in registry

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,11 +32,11 @@ return array(
     'label' => 'QTI Portable Custom Interaction',
     'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '2.2.1',
+    'version' => '2.2.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=9.0.0',
-        'taoQtiItem' => '>=8.13.0'
+        'taoQtiItem' => '>=8.15.0'
     ),
     'acl' => array(
         array('grant', 'http://www.tao.lu/Ontologies/generis.rdf#qtiItemPciManager', array('ext'=>'qtiItemPci')),

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -151,5 +151,7 @@ class Updater extends \common_ext_ExtensionUpdater
             call_user_func(new RegisterPciAudioRecording(), ['0.1.3']);
             $this->setVersion('2.2.1');
         }
+
+        $this->skip('2.2.1', '2.2.2');
     }
 }

--- a/views/js/pciManager/pciManager.js
+++ b/views/js/pciManager/pciManager.js
@@ -26,8 +26,6 @@ define([
     'tpl!qtiItemPci/pciManager/tpl/layout',
     'tpl!qtiItemPci/pciManager/tpl/listing',
     'tpl!qtiItemPci/pciManager/tpl/packageMeta',
-    'taoQtiItem/qtiCreator/editor/interactionsToolbar',
-    'taoQtiItem/portableElementRegistry/ciRegistry',
     'async',
     'ui/dialog/confirm',
     'ui/deleter',
@@ -35,7 +33,7 @@ define([
     'ui/modal',
     'ui/uploader',
     'ui/filesender'
-], function($, __, _, helpers, component, hider, layoutTpl, listingTpl, packageMetaTpl, interactionsToolbar, ciRegistry, asyncLib, confirmBox, deleter, feedback){
+], function($, __, _, helpers, component, hider, layoutTpl, listingTpl, packageMetaTpl, asyncLib, confirmBox, deleter, feedback){
     'use strict';
 
     var _fileTypeFilters = ['application/zip', 'application/x-zip-compressed', 'application/x-zip'],

--- a/views/js/qtiCreator/plugins/panel/pciManager.js
+++ b/views/js/qtiCreator/plugins/panel/pciManager.js
@@ -57,12 +57,14 @@ define([
                     this.trigger('pciEnabled', typeIdentifier);
                 }).on('pciEnabled', function(typeIdentifier){
                     if(interactionsToolbar.exists($interactionSidebar, 'customInteraction.' + typeIdentifier)){
+                        ciRegistry.enable(typeIdentifier);
                         interactionsToolbar.enable($interactionSidebar, 'customInteraction.' + typeIdentifier);
                     }else{
                         ciRegistry.loadCreators({reload: true, enabledOnly : true}).then(function(){
                             var $insertable, $itemBody;
                             var data = ciRegistry.getAuthoringData(typeIdentifier);
                             if(data.tags && data.tags[0] === interactionsToolbar.getCustomInteractionTag()){
+                                ciRegistry.enable(typeIdentifier);
                                 if(!interactionsToolbar.exists($interactionSidebar, data.qtiClass)){
 
                                     //add toolbar button
@@ -82,6 +84,7 @@ define([
                         });
                     }
                 }).on('pciDisabled', function(typeIdentifier){
+                    ciRegistry.disable(typeIdentifier);
                     interactionsToolbar.disable($interactionSidebar, 'customInteraction.' + typeIdentifier);
                 });
 


### PR DESCRIPTION
requires https://github.com/oat-sa/extension-tao-itemqti/pull/972

This fixes an issue found by QA in the custom interaction manager:
1. Disable a pci - disappears from the panel
2. Go back to the tree (without refreshing the page) 
3. Create new item and author
4. Disabled PCI is present in the custom interaction pannel
5. Open the list of PCIs - marked as disabled

(this fix requires a backport for https://github.com/oat-sa/deploy-test-package/commit/9aa138ec7c2afbe35a8bafa850a11b744571ac68, coming soon)