### PR TITLE
Fix/tao 4771 allow submit in preview

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI Portable Custom Interaction',
     'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '3.6.0',
+    'version' => '3.6.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=9.2.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -274,5 +274,10 @@ class Updater extends \common_ext_ExtensionUpdater
             call_user_func(new RegisterPciMathEntry(), ['0.7.0']);
             $this->setVersion('3.6.0');
         }
+
+        if($this->isVersion('3.6.0')){
+            call_user_func(new RegisterPciAudioRecording(), ['0.2.2']);
+            $this->setVersion('3.6.1');
+        }
     }
 }

--- a/views/js/pciCreator/dev/audioRecordingInteraction/pciCreator.json
+++ b/views/js/pciCreator/dev/audioRecordingInteraction/pciCreator.json
@@ -3,7 +3,7 @@
     "label": "Audio recording",
     "short": "Audio",
     "description": "Allow test taker to record audio",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "author": "Christophe Noël",
     "email": "christophe@taotesting.com",
     "tags": [

--- a/views/js/pciCreator/dev/audioRecordingInteraction/runtime/audioRecordingInteraction.js
+++ b/views/js/pciCreator/dev/audioRecordingInteraction/runtime/audioRecordingInteraction.js
@@ -638,13 +638,14 @@ define([
          * @returns {Object}
          */
         getResponse: function getResponse() {
+            var response;
+
             if (this._recording) {
-                return {
-                    base: {
-                        file: this._recording
-                    }
-                };
+                response = { file: this._recording };
             }
+            return {
+                base: response
+            };
         },
         /**
          * Remove the current response set in the interaction

--- a/views/js/test/audioRecordingInteraction/test.js
+++ b/views/js/test/audioRecordingInteraction/test.js
@@ -139,7 +139,8 @@ define([
                         interaction.resetResponse();
                     } else if (changeCounter === 2) {
                         assert.ok(_.isPlainObject(res), 'response changed');
-                        assert.ok(_.isUndefined(res.RESPONSE), 'no response is given when there is no recording');
+                        assert.ok(_.isPlainObject(res.RESPONSE), 'response identifier ok');
+                        assert.ok(_.isUndefined(res.RESPONSE.base), 'no response is given when there is no recording');
                         QUnit.start();
                     }
                 })


### PR DESCRIPTION
Without this fix, clicking the "submit" button while previewing a item with the Audio PCI has no effect.