### PR TITLE
Fix/tao 5795 audio pci ui menus does not reflect actual options

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI Portable Custom Interaction',
     'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '4.5.0',
+    'version' => '4.5.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=15.4.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -297,5 +297,10 @@ class Updater extends \common_ext_ExtensionUpdater
             call_user_func(new RegisterPciAudioRecording(), ['0.3.0']);
             $this->setVersion('4.5.0');
         }
+
+        if($this->isVersion('4.5.0')){
+            call_user_func(new RegisterPciAudioRecording(), ['0.3.1']);
+            $this->setVersion('4.5.1');
+        }
     }
 }

--- a/views/js/pciCreator/dev/audioRecordingInteraction/creator/tpl/propertiesForm.tpl
+++ b/views/js/pciCreator/dev/audioRecordingInteraction/creator/tpl/propertiesForm.tpl
@@ -57,8 +57,8 @@
         {{__ "With compressed recording, the audio is saved as a webm or ogg file (smaller size). With uncompressed, as a lossless Wav file (much bigger size)."}}
     </span>
     <select name="isCompressed">
-        <option value="true">{{__ 'Compressed'}}</option>
-        <option value="false">{{__ 'Uncompressed'}}</option>
+        <option value="true"{{#if isCompressed}} selected="selected"{{/if}}>{{__ 'Compressed'}}</option>
+        <option value="false"{{#unless isCompressed}} selected="selected"{{/unless}}>{{__ 'Uncompressed'}}</option>
     </select>
 </div>
 
@@ -81,8 +81,8 @@
             {{__ "Number of channels for the recording. Allow to cut the record size in half if used in mono."}}
         </span>
         <select name="isStereo">
-            <option value="false">{{__ 'Mono'}}</option>
-            <option value="true">{{__ 'Stereo'}}</option>
+            <option value="false"{{#unless isStereo}} selected="selected"{{/unless}}>{{__ 'Mono'}}</option>
+            <option value="true"{{#if isStereo}} selected="selected"{{/if}}>{{__ 'Stereo'}}</option>
         </select>
     </div>
 </div>

--- a/views/js/pciCreator/dev/audioRecordingInteraction/pciCreator.json
+++ b/views/js/pciCreator/dev/audioRecordingInteraction/pciCreator.json
@@ -3,7 +3,7 @@
     "label": "Audio recording",
     "short": "Audio",
     "description": "Allow test taker to record audio",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "author": "Christophe Noël",
     "email": "christophe@taotesting.com",
     "tags": [


### PR DESCRIPTION
The dropdown menus "Recording format" and "Channels" could be used to set corresponding options, but when saving and re-opening an item, they would fallback to their default values, although the options were correctly set.