### PR TITLE
Modify partial encoding to be optional

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI Portable Custom Interaction',
     'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '4.7.1',
+    'version' => '4.8.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=15.4.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -323,5 +323,10 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         $this->skip('4.7.0', '4.7.1');
+
+        if ($this->isVersion('4.7.1')) {
+            call_user_func(new RegisterPciAudioRecording(), ['0.6.0']);
+            $this->setVersion('4.8.0');
+        }
     }
 }

--- a/views/js/pciCreator/dev/audioRecordingInteraction/pciCreator.js
+++ b/views/js/pciCreator/dev/audioRecordingInteraction/pciCreator.js
@@ -51,23 +51,24 @@ define([
          */
         getDefaultProperties : function getDefaultProperties(){
             return {
-                allowPlayback:      true,
-                autoStart:          false,
-                maxRecords:         2,
-                maxRecordingTime:   120,
+                allowPlayback:           true,
+                autoStart:               false,
+                maxRecords:              2,
+                maxRecordingTime:        120,
 
-                isCompressed:       true,
-                audioBitrate:       20000,
-                isStereo:           false,
+                isCompressed:            true,
+                audioBitrate:            20000,
+                isStereo:                false,
 
-                useMediaStimulus:   false,
+                useMediaStimulus:        false,
                 media: {
-                    autostart:      true,
-                    replayTimeout:  5,
-                    maxPlays:       2
+                    autostart:           true,
+                    replayTimeout:       5,
+                    maxPlays:            2
                 },
 
-                displayDownloadLink: false
+                displayDownloadLink:     false,
+                updateResponsePartially: false,
             };
         },
         /**

--- a/views/js/pciCreator/dev/audioRecordingInteraction/pciCreator.json
+++ b/views/js/pciCreator/dev/audioRecordingInteraction/pciCreator.json
@@ -3,7 +3,7 @@
     "label": "Audio recording",
     "short": "Audio",
     "description": "Allow test taker to record audio",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "author": "Christophe Noël",
     "email": "christophe@taotesting.com",
     "tags": [

--- a/views/js/pciCreator/dev/audioRecordingInteraction/runtime/audioRecordingInteraction.js
+++ b/views/js/pciCreator/dev/audioRecordingInteraction/runtime/audioRecordingInteraction.js
@@ -113,22 +113,24 @@ define([
          * @param {Boolean} config.useMediaStimulus - will display a media stimulus to the test taker
          * @param {Object}  config.media - media object (handled by the PCI media manager helper)
          * @param {Boolean} config.displayDownloadLink - for testing purposes only: allow to download the recorded file
+         * @param {Boolean} config.updateResponsePartially - enable/disable the partial response update (may affect the performance)
          */
         initConfig: function init(config) {
             this.config = {
-                allowPlayback:          toBoolean(config.allowPlayback, true),
-                autoStart:              toBoolean(config.autoStart, false),
-                maxRecords:             toInteger(config.maxRecords, 3),
-                maxRecordingTime:       toInteger(config.maxRecordingTime, 120),
+                allowPlayback:           toBoolean(config.allowPlayback, true),
+                autoStart:               toBoolean(config.autoStart, false),
+                maxRecords:              toInteger(config.maxRecords, 3),
+                maxRecordingTime:        toInteger(config.maxRecordingTime, 120),
 
-                isCompressed:           toBoolean(config.isCompressed, true),
-                audioBitrate:           toInteger(config.audioBitrate, 20000),
-                isStereo:               toBoolean(config.isStereo, false),
+                isCompressed:            toBoolean(config.isCompressed, true),
+                audioBitrate:            toInteger(config.audioBitrate, 20000),
+                isStereo:                toBoolean(config.isStereo, false),
 
-                useMediaStimulus:       toBoolean(config.useMediaStimulus, false),
-                media:                  config.media || {},
+                useMediaStimulus:        toBoolean(config.useMediaStimulus, false),
+                media:                   config.media || {},
 
-                displayDownloadLink:    toBoolean(config.displayDownloadLink, false)
+                displayDownloadLink:     toBoolean(config.displayDownloadLink, false),
+                updateResponsePartially: toBoolean(config.updateResponsePartially, false),
             };
         },
 

--- a/views/js/pciCreator/dev/audioRecordingInteraction/runtime/js/providers/mediaRecorder.js
+++ b/views/js/pciCreator/dev/audioRecordingInteraction/runtime/js/providers/mediaRecorder.js
@@ -81,8 +81,10 @@ define([
 
                     chunks.push(e.data);
 
-                    blob = new Blob(chunks, {type: mimeType});
-                    self.trigger('partialblobavailable', [blob]);
+                    if (config.updateResponsePartially) {
+                        blob = new Blob(chunks, {type: mimeType});
+                        self.trigger('partialblobavailable', [blob]);
+                    }
                 };
 
                 // stop record callback

--- a/views/js/pciCreator/dev/audioRecordingInteraction/runtime/js/providers/webAudio.js
+++ b/views/js/pciCreator/dev/audioRecordingInteraction/runtime/js/providers/webAudio.js
@@ -46,6 +46,8 @@ define([
         var numChannels = (config.isStereo) ? 2 : 1,
             buffer = [];
 
+        var updateResponsePartially = config.updateResponsePartially;
+
         /**
          * Load the worker and configure it
          */
@@ -55,7 +57,8 @@ define([
             sendToWorker('init', {
                 config: {
                     numChannels: numChannels,
-                    sampleRate: audioContext.sampleRate
+                    sampleRate: audioContext.sampleRate,
+                    updateResponsePartially: updateResponsePartially,
                 },
                 options: {
                     timeLimit: 0,           // time limit is handled by the provider wrapper

--- a/views/js/pciCreator/dev/audioRecordingInteraction/runtime/js/workers/WebAudioRecorderWav.js
+++ b/views/js/pciCreator/dev/audioRecordingInteraction/runtime/js/workers/WebAudioRecorderWav.js
@@ -47,7 +47,7 @@ function init(data) {
     numChannels = data.config.numChannels;
     options = data.options;
     updateResponsePartially = data.config.updateResponsePartially;
-};
+}
 
 function setOptions(opt) {
     if (encoder || recBuffers)

--- a/views/js/pciCreator/dev/audioRecordingInteraction/runtime/js/workers/WebAudioRecorderWav.js
+++ b/views/js/pciCreator/dev/audioRecordingInteraction/runtime/js/workers/WebAudioRecorderWav.js
@@ -35,7 +35,8 @@ var sampleRate = 44100,
     maxBuffers = undefined,
     encoder = undefined,
     recBuffers = undefined,
-    bufferCount = 0;
+    bufferCount = 0,
+    updateResponsePartially;
 
 function error(message) {
     self.postMessage({ command: "error", message: "wav: " + message });
@@ -45,6 +46,7 @@ function init(data) {
     sampleRate = data.config.sampleRate;
     numChannels = data.config.numChannels;
     options = data.options;
+    updateResponsePartially = data.config.updateResponsePartially;
 };
 
 function setOptions(opt) {
@@ -67,10 +69,12 @@ function record(buffer) {
         if (encoder) {
             encoder.encode(buffer);
 
-            self.postMessage({
-                command: "partialcomplete",
-                blob: encoder.partialFinish(options.wav.mimeType),
-            });
+            if (updateResponsePartially) {
+                self.postMessage({
+                    command: "partialcomplete",
+                    blob: encoder.partialFinish(options.wav.mimeType),
+                });
+            }
 
         } else {
             recBuffers.push(buffer);


### PR DESCRIPTION
New config attribute added to make the partial encoding optional, as it caused some performance issues in weaker PCs. The value of it is `false` by default.

**How to test:**
- Checkout the branch and run update process
- Create a new Item which contains an audio PCI
- Select Compressed / Uncompressed recording format
- Preview

**Expected:** The recording should work without any issue.

---

**Additional testing:** Run `grunt connect:test:keepalive` in `tao/views/build` and open `http://127.0.0.1:8082/qtiItemPci/views/js/test/audioRecordingInteraction/test.html`. At the bottom you can test the PCI. Be sure that when you are recording the displayed `RESPONSE` is not changing. Then open `qtiItemPci/views/js/test/audioRecordingInteraction/data/qti.json` and `"updateResponsePartially": "true"` in line 46 (under the other properties) and test again in the browser. In this case the `RESPONSE` should get updated continously while recording.