### PR TITLE
Fix/TAO-7216/unit test data need to be encoded

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'QTI Portable Custom Interaction',
     'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '5.3.3',
+    'version' => '5.3.4',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=30.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -371,5 +371,7 @@ class Updater extends \common_ext_ExtensionUpdater
             call_user_func(new RegisterPciAudioRecording(), ['0.9.2']);
             $this->setVersion('5.3.3');
         }
+
+        $this->skip('5.3.3', '5.3.4');
     }
 }

--- a/views/js/test/audioRecordingInteraction/test.js
+++ b/views/js/test/audioRecordingInteraction/test.js
@@ -203,7 +203,7 @@ define([
                 file: {
                     name: 'myFileToBeReseted',
                     mime: 'audio/wav',
-                    data: 'base64encodedData'
+                    data: 'YmFzZTY0ZW5jb2RlZERhdGE='
                 }
             }
         };
@@ -259,7 +259,7 @@ define([
                     file: {
                         name: 'myFileToBeReseted',
                         mime: 'audio/wav',
-                        data: 'base64encodedData'
+                        data: 'YmFzZTY0ZW5jb2RlZERhdGE='
                     }
                 }
             }


### PR DESCRIPTION
For the unit test, we need to use an encoded string in field response.file.data

To test: 
- cd tao/views/build 
- npm i 
- grunt connect:test qunit:single --test=/qtiItemPci/views/js/test/audioRecordingInteraction/test.html