### PR TITLE
Fix/tao 9736 unanswered audio interaction state

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'QTI Portable Custom Interaction',
     'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '4.9.1',
+    'version' => '4.9.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=15.4.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -338,5 +338,10 @@ class Updater extends \common_ext_ExtensionUpdater
             call_user_func(new RegisterPciAudioRecording(), ['0.7.1']);
             $this->setVersion('4.9.1');
         }
+
+        if ($this->isVersion('4.9.1')) {
+            call_user_func(new RegisterPciAudioRecording(), ['0.7.2']);
+            $this->setVersion('4.9.2');
+        }
     }
 }

--- a/views/js/pciCreator/dev/audioRecordingInteraction/pciCreator.json
+++ b/views/js/pciCreator/dev/audioRecordingInteraction/pciCreator.json
@@ -3,7 +3,7 @@
     "label": "Audio recording",
     "short": "Audio",
     "description": "Allow test taker to record audio",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "author": "Christophe Noël",
     "email": "christophe@taotesting.com",
     "tags": [

--- a/views/js/pciCreator/dev/audioRecordingInteraction/runtime/audioRecordingInteraction.js
+++ b/views/js/pciCreator/dev/audioRecordingInteraction/runtime/audioRecordingInteraction.js
@@ -665,7 +665,7 @@ define([
          * @returns {Object}
          */
         getResponse: function getResponse() {
-            var response;
+            var response = null;
 
             if (this.getRecording()) {
                 response = { file: this.getRecording() };


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-9736

With `response` variable being `undefined`, interaction response does not get serialized in a way that the review panel will detect it as not responded. By forcing the value to null - which is the default behavior of other interaction - interaction state is properly recognized.

If a recording is made, then deleted, no fix is necessary as the interaction was already resetting the response in a proper way. 
