### PR TITLE
Fix/tao 9736/Broken unit test in audiorecording

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'QTI Portable Custom Interaction',
     'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '6.1.1',
+    'version' => '6.1.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -394,5 +394,7 @@ class Updater extends \common_ext_ExtensionUpdater
             call_user_func(new RegisterPciAudioRecording(), ['0.9.3']);
             $this->setVersion('6.1.1');
         }
+
+        $this->skip('6.1.1', '6.1.2');
     }
 }

--- a/views/js/test/audioRecordingInteraction/test.js
+++ b/views/js/test/audioRecordingInteraction/test.js
@@ -173,7 +173,7 @@ define([
                     } else if (changeCounter === 2) {
                         assert.ok(_.isPlainObject(res), 'response changed');
                         assert.ok(_.isPlainObject(res.RESPONSE), 'response identifier ok');
-                        assert.ok(_.isUndefined(res.RESPONSE.base), 'no response is given when there is no recording');
+                        assert.strictEqual(res.RESPONSE.base, null, 'no response is given when there is no recording');
                         ready();
                     }
                 })


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9736

With the last fix for the `audioRecording` interaction, regarding the default response value, the unit tests have not been updated and were failing.
