### PR TITLE
fix: remove mathEntryInteraction from PCI registry

### DIFF
--- a/migrations/Version202103260728031465_qtiItemPci.php
+++ b/migrations/Version202103260728031465_qtiItemPci.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\qtiItemPci\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use Doctrine\Migrations\Exception\IrreversibleMigration;
+use oat\qtiItemPci\model\PciModel;
+use oat\qtiItemPci\scripts\install\RegisterPciMathEntry;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202103260728031465_qtiItemPci extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Remove Math Entry interaction from PCI registry';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $registry = (new PciModel())->getRegistry();
+        if ($registry->has('mathEntryInteraction')) {
+            /** @noinspection PhpUnhandledExceptionInspection */
+            $registry->removeAllVersions('mathEntryInteraction');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        throw new IrreversibleMigration(
+            'In order to undo this migration, please revert the client-side changes and run ' . RegisterPciMathEntry::class
+        );
+    }
+}


### PR DESCRIPTION
It is a fix of https://github.com/oat-sa/extension-tao-itemqti-pci/releases/tag/v6.10.0, where `mathEntryInteraction` was removed from `IMSPciModel` registry, although at that time it was registered under `PciModel` registry.

Test:
- Checkout a version below `v6.10.0`
- Update to this branch and run `taoUpdate`
- `mathEntryInteraction` should be removed from Pci registry and it should be registered only in IMS Pci registry.