### PR TITLE
fix: Wrong PCI package version was disabled

### DIFF
--- a/controller/PciManager.php
+++ b/controller/PciManager.php
@@ -264,14 +264,20 @@ class PciManager extends \tao_actions_CommonModule
         $typeIdentifier = $this->getRequestParameter('typeIdentifier');
 
         $pciModels = $this->getPciModels();
+        $pciDataObjects = [];
         foreach ($pciModels as $pciModel) {
             try {
                 $pciDataObject = $pciModel->getRegistry()->getLatestVersion($typeIdentifier);
                 if (!is_null($pciDataObject)) {
-                    return $pciDataObject;
+                    $pciDataObjects[$typeIdentifier] = $pciDataObject;
                 }
             } catch (PortableElementNotFoundException $e) {
+                continue;
             }
+        }
+
+        if (!empty($pciDataObjects)) {
+            return $pciDataObjects[$typeIdentifier];
         }
 
         throw new PortableElementException('Element not found');


### PR DESCRIPTION
Ticket - https://oat-sa.atlassian.net/browse/OATSD-1810

When 2 versions of the same PCI package have been installed (PCI and IMSPCI) only the PCI version was taken into account during disabling and enabling the package. Now in case of PCI and IMSPCI versions installed IMSPCI version is taken into account.

How to test the fix:

- Install TAO with the latest version of qtiItemPci extension
- Upload the OAT PCI nteraction (for example textReaderInteraction v1.0.0)
- Upload the IMS PCI interaction (for example textReaderInteraction v1.1.0). In case of bug with UI uploading upload it manually
- Try to disable the textReaderInteraction and reload the page (interaction should remain enabled)
- Switch to the branch with fix
- Try to disable the textReaderInteraction and reload the page (interaction should be disabled)
