### PR TITLE
fix/MS-2245_send-error-message-before-exit

### DIFF
--- a/controller/PciManager.php
+++ b/controller/PciManager.php
@@ -161,7 +161,7 @@ class PciManager extends \tao_actions_CommonModule
                 ['messages' => $invalidModelErrors]
             ];
             $this->returnJson($result);
-            exit();
+            return;
         }
 
         if ($pciObject->hasVersion()) {
@@ -185,7 +185,7 @@ class PciManager extends \tao_actions_CommonModule
                 ]];
                 $result['valid'] = false;
                 $this->returnJson($result);
-                exit();
+                return;
             }
         }
 


### PR DESCRIPTION
Script is terminated before response is sent, so FE fails on JSON parsing of empty response.

Test:
- Have a TAO and upload a wrong PCI under Gear icon/Portable Custom Interaction
- You should have an error instead of empty response

Wrong PCI example:
[ClinicalSimulation_v1.0.0 (1).zip](https://github.com/oat-sa/extension-tao-itemqti-pci/files/9085182/ClinicalSimulation_v1.0.0.1.zip)
 