### PR TITLE
fix: prevent export failing due to type error

### DIFF
--- a/model/portableElement/export/ImsPciExporter.php
+++ b/model/portableElement/export/ImsPciExporter.php
@@ -110,7 +110,9 @@ class ImsPciExporter extends PortableElementExporter
             /** @var \DOMElement $resourcesNode */
             $modulesNode = $currentPortableNode->getElementsByTagName('modules')->item(0);
 
-            $this->removeOldNode($modulesNode, 'module');
+            if (!empty($modulesNode)) {
+                $this->removeOldNode($modulesNode, 'module');
+            }
 
             $runtime = $portableElement->getRuntime();
             if (isset($runtime['config'])) {


### PR DESCRIPTION
In scope of transforming OAT TextReader PCI content to IMS TextReader we got xml objects without <modules> tag:
```
  ...
    </properties>
    <modules>
    </modules>
    <markup xmlns="http://www.w3.org/1999/xhtml">
    ...
   </markup>
  </portableCustomInteraction>
  </customInteraction>
  ...
```
that way one place in export code fails where it tries to find that tag and remove it from DOM
``` 
2022-12-07 09:38:24 [ERROR] [tao] 'Executing task <https://ent-depp.docker.localhost/ontologies/tao.rdf#i63905f10c82483587b6ab8b5998f248> failed with MSG: Argument 1 passed to oat\taoQtiItem\model\portableElement\export\PortableElementExporter::removeOldNode() must be an instance of DOMNode, null given, called in /var/www/html/qtiItemPci/model/portableElement/export/ImsPciExporter.php on line 113' /var/www/html/tao/models/classes/taskQueue/Worker/AbstractWorker.php 108
```
When author creates a new item with IMS text reader it saves xml with `<modules>` empty so as I see we not using it to store anything cause we getting data from registry and we only adding that tag when we export in order keep there some references. So it looks enough to fix that place to not fail if empty `<modules>` object missing.