### PR TITLE
Move data-allow-copy attribute

### DIFF
--- a/views/js/pciCreator/ims/mathEntryInteraction/creator/tpl/markup.tpl
+++ b/views/js/pciCreator/ims/mathEntryInteraction/creator/tpl/markup.tpl
@@ -2,8 +2,8 @@
     <div class="prompt">{{{prompt}}}</div>
     <div class="math-entry">
         <div class="toolbar"></div>
-        <div>
-            <span class="math-entry-input" data-allow-copy="true"></span>
+        <div data-allow-copy="true">
+            <span class="math-entry-input"></span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/TR-5243

## What's Changed

- Moved `data-allow-copy` attribute to another element for it to avoid being removed.