### PR TITLE
Fix: update to invokeMap for portableElements lodash 4

### DIFF
--- a/views/js/pciCreator/dev/audioRecordingInteraction/runtime/audioRecordingInteraction.js
+++ b/views/js/pciCreator/dev/audioRecordingInteraction/runtime/audioRecordingInteraction.js
@@ -800,14 +800,14 @@ define([
             if (this._delayCallback || this.countdown && this.countdown.isDisplayed()) {
                 return;
             }
-            _.invoke(this.controls, 'updateState');
+            _.invokeMap(this.controls, 'updateState');
         },
 
         /**
          * Destroy the state of all the controls
          */
         destroyControls: function destroyControls() {
-            _.invoke(this.controls, 'destroy');
+            _.invokeMap(this.controls, 'destroy');
             this.controls = null;
         },
 


### PR DESCRIPTION
While working on https://github.com/oat-sa/extension-tao-itemqti-pci/pull/394 I noticed a failing unit test in the repo. It's due to the [lodash change](https://github.com/oat-sa/extension-tao-itemqti/pull/2426/commits/9fc232b0097297d34e9aa9ad499177088f9977ab) in portableElements:
- `portableElements/lodash.js` is now v4
- `portableElements/lodash_2_4_1.js` is v2

Anyway, v2 usage of [invoke](https://lodash.com/docs/2.4.2#invoke) should be changed for [invokeMap](https://lodash.com/docs/4.17.15#invokeMap) in lodash 4.

(Note: the `dev/audioRecordingInteraction` PCI shouldn't be maintained anyway, but hasn't been removed yet.)

To test: from tao/views/build, `npx grunt connect:dev qtiitempcitest`