### PR TITLE
chore: extend the maximum allowed time limit of the recording via Audio PCI up to 30 minutes

### DIFF
--- a/migrations/Version202411201142151465_qtiItemPci.php
+++ b/migrations/Version202411201142151465_qtiItemPci.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\qtiItemPci\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\reporting\ReportInterface;
+use oat\qtiItemPci\model\portableElement\configuration\AudioRecordingInteractionCreatorConfigurationRegistry;
+use oat\qtiItemPci\scripts\install\SetupAudioRecordingInteractionCreatorConfigurationRegistry;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202411201142151465_qtiItemPci extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set the Audio PCI maximum allowed time limit to 1800 seconds';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $report = $this->propagate(new SetupAudioRecordingInteractionCreatorConfigurationRegistry())([]);
+
+        $this->abortIf(
+            $report->getType() === ReportInterface::TYPE_ERROR,
+            $report->getMessage()
+        );
+
+        $this->addReport(
+            $report
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        /** @var AudioRecordingInteractionCreatorConfigurationRegistry $audioRecordingCreatorConfigurationRegistry */
+        $audioRecordingCreatorConfigurationRegistry = $this->getServiceLocator()->getContainer()
+            ->get(AudioRecordingInteractionCreatorConfigurationRegistry::class);
+
+        $audioRecordingCreatorConfigurationRegistry->setMaximumRecordingTimeLimit(60 * 20);
+    }
+}

--- a/scripts/install/SetupAudioRecordingInteractionCreatorConfigurationRegistry.php
+++ b/scripts/install/SetupAudioRecordingInteractionCreatorConfigurationRegistry.php
@@ -15,9 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
- *
- * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ * Copyright (c) 2020-2024 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
@@ -34,7 +32,7 @@ class SetupAudioRecordingInteractionCreatorConfigurationRegistry extends ScriptA
     public const MAXIMUM_RECORDING_TIME_LIMIT = 'maximumRecordingTimeLimit';
 
     private const OPTION_DEFAULT_VALUES = [
-        self::MAXIMUM_RECORDING_TIME_LIMIT => 60 * 20,
+        self::MAXIMUM_RECORDING_TIME_LIMIT => 60 * 30,
     ];
 
     protected function provideOptions(): array


### PR DESCRIPTION
# [AUT-3975](https://oat-sa.atlassian.net/browse/AUT-3975)

This PR is pretty simple; it allows the item authors to set the Audio PCI recording duration up to 30 minutes instead of 20.

[AUT-3975]: https://oat-sa.atlassian.net/browse/AUT-3975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ