### PR TITLE
fix: update mathquill library

### DIFF
--- a/migrations/Version202503131356361465_qtiItemPci.php
+++ b/migrations/Version202503131356361465_qtiItemPci.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\qtiItemPci\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use Doctrine\Migrations\Exception\IrreversibleMigration;
+use oat\qtiItemPci\scripts\install\RegisterPciMathEntry;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202502210933441465_qtiItemPci extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update the Math Entry PCI with fixes for Japanese IME';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addReport(
+            $this->propagate(
+                new RegisterPciMathEntry()
+            )(
+                ['2.7.1']
+            )
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        throw new IrreversibleMigration(
+            'In order to undo this migration, please revert the client-side changes and run ' . RegisterPciMathEntry::class
+        );
+    }
+}

--- a/migrations/Version202503131356361465_qtiItemPci.php
+++ b/migrations/Version202503131356361465_qtiItemPci.php
@@ -14,7 +14,7 @@ use oat\qtiItemPci\scripts\install\RegisterPciMathEntry;
  *
  * phpcs:disable Squiz.Classes.ValidClassName
  */
-final class Version202502210933441465_qtiItemPci extends AbstractMigration
+final class Version202503131356361465_qtiItemPci extends AbstractMigration
 {
     public function getDescription(): string
     {

--- a/views/js/pciCreator/ims/mathEntryInteraction/imsPciCreator.json
+++ b/views/js/pciCreator/ims/mathEntryInteraction/imsPciCreator.json
@@ -8,7 +8,7 @@
     "label": "Math entry",
     "short": "Math entry",
     "description": "Allow test taker to type math formulas",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "author": "Christophe Noël",
     "email": "christophe@taotesting.com",
     "tags": [

--- a/views/js/pciCreator/ims/mathEntryInteraction/package-lock.json
+++ b/views/js/pciCreator/ims/mathEntryInteraction/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mathentryinteraction",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mathentryinteraction",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "license": "GPL-2.0-only",
             "devDependencies": {
                 "@rollup/plugin-commonjs": "^22.0.2",

--- a/views/js/pciCreator/ims/mathEntryInteraction/package.json
+++ b/views/js/pciCreator/ims/mathEntryInteraction/package.json
@@ -1,7 +1,7 @@
 {
     "name": "mathentryinteraction",
     "private": true,
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Manage the dependencies of mathEntryInteraction",
     "scripts": {
         "build": "rollup --config"

--- a/views/js/pciCreator/ims/mathEntryInteraction/runtime/mathquill/mathquill.js
+++ b/views/js/pciCreator/ims/mathEntryInteraction/runtime/mathquill/mathquill.js
@@ -1,5 +1,5 @@
 /**
- * MathQuill v0.10.1, by Han, Jeanine, and Mary
+ * MathQuill v0.10.2, by Han, Jeanine, and Mary
  * http://mathquill.com | maintainers@mathquill.com
  *
  * This Source Code Form is subject to the terms of the
@@ -1468,6 +1468,7 @@ var saneKeyboardEvents = (function() {
 
     144: 'NumLock'
   };
+  var SPECIAL_KEYS = Object.keys(KEY_VALUES).map(function (key) { return KEY_VALUES[key]; });
 
   // To the extent possible, create a normalized string representation
   // of the key combo (i.e., key code and modifier keys).
@@ -1476,6 +1477,10 @@ var saneKeyboardEvents = (function() {
     var keyVal = KEY_VALUES[which];
     var key;
     var modifiers = [];
+    var originalEventKey = evt.originalEvent && evt.originalEvent.key;
+    if (!keyVal && SPECIAL_KEYS.indexOf(originalEventKey) !== -1) {
+        keyVal = originalEventKey;
+    }
 
     if (evt.ctrlKey) modifiers.push('Ctrl');
     if (evt.originalEvent && evt.originalEvent.metaKey) modifiers.push('Meta');
@@ -1492,7 +1497,15 @@ var saneKeyboardEvents = (function() {
   function isVisibleKey(evt) {
     var which = evt.which || evt.keyCode;
     var keyVal = KEY_VALUES[which];
-    return !(evt.ctrlKey || evt.originalEvent && evt.originalEvent.metaKey || evt.altKey || evt.shiftKey || keyVal);
+    var originalEventKey = evt.originalEvent && evt.originalEvent.key;
+    if (!keyVal && SPECIAL_KEYS.indexOf(originalEventKey) !== -1) {
+        keyVal = originalEventKey;
+    }
+    return !(evt.ctrlKey ||
+        (evt.originalEvent && evt.originalEvent.metaKey) ||
+        evt.altKey ||
+        evt.shiftKey ||
+        keyVal);
   }
   function isIpadOS() {
     return navigator.maxTouchPoints &&


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/INF-300

## What's Changed

- Update mathquill library to fix issue with Japanese IME

## TODO 

- [x] Generate migration

## How to test
- Install this version of extension in the backoffice
- Create new delivery using MathEntry interaction
- Launch new delivery
- Repeat steps from https://github.com/oat-sa/mathquill/pull/13 with newly created delivery