### PR TITLE
Feature/TR-6795/Provide PCI list externally or internally

### DIFF
--- a/controller/PciLoader.php
+++ b/controller/PciLoader.php
@@ -13,9 +13,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Foundation, Inc., 31 Milk Street, # 960789, Boston, MA 02196, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2016-2026 (original work) Open Assessment Technologies SA;
  *
  */
 

--- a/controller/PciLoader.php
+++ b/controller/PciLoader.php
@@ -29,79 +29,88 @@ use tao_actions_CommonModule;
 class PciLoader extends tao_actions_CommonModule
 {
     /**
-     * Load latest PCI runtimes
+     * Load latest PCI runtimes (controller action)
      */
     public function load()
+    {
+        try {
+            $result = $this->getLatestPciRuntimes();
+            $this->returnJson($result);
+        } catch (PortableElementException $e) {
+            $this->returnJson($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * Get latest PCI runtimes data
+     *
+     * @return array
+     */
+    public function getLatestPciRuntimes(): array
     {
         $customInteractionDirs = \common_ext_ExtensionsManager::singleton()
             ->getExtensionById('taoQtiItem')
             ->getConfig('debug_portable_element');
 
-        try {
-            $result = array_reduce($this->getRegistries(), function ($acc, $registry) use ($customInteractionDirs) {
-                $latestRuntimes = $registry->getLatestRuntimes();
-                if (is_array($customInteractionDirs)) {
-                    foreach ($latestRuntimes as $id => &$versions) {
-                        if (isset($customInteractionDirs[$id])) {
-                            //add option to load from source (as opposed to from the default min.js files)
-                            foreach ($versions as &$version) {
-                                // IMS PCI
-                                if (isset($version['model']) && $version['model'] == 'IMSPCI') {
-                                    $modules = (isset($version['runtime']) && isset($version['runtime']['modules']))
-                                        ? $version['runtime']['modules']
-                                        : [];
-                                    $src = (isset($version['runtime']) && isset($version['runtime']['src']))
-                                        ? $version['runtime']['src']
-                                        : [];
+        return array_reduce($this->getRegistries(), function ($acc, $registry) use ($customInteractionDirs) {
+            $latestRuntimes = $registry->getLatestRuntimes();
+            if (is_array($customInteractionDirs)) {
+                foreach ($latestRuntimes as $id => &$versions) {
+                    if (isset($customInteractionDirs[$id])) {
+                        //add option to load from source (as opposed to from the default min.js files)
+                        foreach ($versions as &$version) {
+                            // IMS PCI
+                            if (isset($version['model']) && $version['model'] == 'IMSPCI') {
+                                $modules = (isset($version['runtime']) && isset($version['runtime']['modules']))
+                                    ? $version['runtime']['modules']
+                                    : [];
+                                $src = (isset($version['runtime']) && isset($version['runtime']['src']))
+                                    ? $version['runtime']['src']
+                                    : [];
 
-                                    // in case of a TAO bundled PCI (= we have a "src" entry),
-                                    // we redirect the module to the entry point of the PCI instead of its minified
-                                    // version
-                                    if (count($src) > 0) {
-                                        foreach ($modules as $moduleKey => &$allModulesFiles) {
-                                            if (strpos($moduleKey, '.min') == (strlen($moduleKey) - strlen('.min'))) {
-                                                foreach ($allModulesFiles as &$moduleFile) {
-                                                    $moduleFile = str_replace('.min.js', '.js', $moduleFile);
-                                                }
+                                // in case of a TAO bundled PCI (= we have a "src" entry),
+                                // we redirect the module to the entry point of the PCI instead of its minified
+                                // version
+                                if (count($src) > 0) {
+                                    foreach ($modules as $moduleKey => &$allModulesFiles) {
+                                        if (strpos($moduleKey, '.min') == (strlen($moduleKey) - strlen('.min'))) {
+                                            foreach ($allModulesFiles as &$moduleFile) {
+                                                $moduleFile = str_replace('.min.js', '.js', $moduleFile);
                                             }
                                         }
                                     }
+                                }
 
-                                    if (isset($version['runtime']) && isset($version['runtime']['modules'])) {
-                                        $version['runtime']['modules'] = $modules;
-                                    }
-                                    if (isset($version['creator']) && isset($version['creator']['src'])) {
-                                        //the first entry of the src array is always the entrypoint (PCI hook)
-                                        $version['creator']['hook'] = array_shift($version['creator']['src']);
-                                        $version['creator']['modules'] = $version['creator']['src'];
-                                        unset($version['creator']['src']);
-                                    }
+                                if (isset($version['runtime']) && isset($version['runtime']['modules'])) {
+                                    $version['runtime']['modules'] = $modules;
+                                }
+                                if (isset($version['creator']) && isset($version['creator']['src'])) {
+                                    //the first entry of the src array is always the entrypoint (PCI hook)
+                                    $version['creator']['hook'] = array_shift($version['creator']['src']);
+                                    $version['creator']['modules'] = $version['creator']['src'];
+                                    unset($version['creator']['src']);
+                                }
 
-                                    // TAO PCI
-                                } else {
-                                    if (isset($version['runtime']) && isset($version['runtime']['src'])) {
-                                        $version['runtime']['libraries'] = $version['runtime']['src'];
-                                        unset($version['runtime']['hook']);
-                                        unset($version['runtime']['src']);
-                                    }
-                                    if (isset($version['creator']) && isset($version['creator']['src'])) {
-                                        //the first entry of the src array is always the entrypoint (PCI hook)
-                                        $version['creator']['hook'] = array_shift($version['creator']['src']);
-                                        $version['creator']['modules'] = $version['creator']['src'];
-                                        unset($version['creator']['src']);
-                                    }
+                                // TAO PCI
+                            } else {
+                                if (isset($version['runtime']) && isset($version['runtime']['src'])) {
+                                    $version['runtime']['libraries'] = $version['runtime']['src'];
+                                    unset($version['runtime']['hook']);
+                                    unset($version['runtime']['src']);
+                                }
+                                if (isset($version['creator']) && isset($version['creator']['src'])) {
+                                    //the first entry of the src array is always the entrypoint (PCI hook)
+                                    $version['creator']['hook'] = array_shift($version['creator']['src']);
+                                    $version['creator']['modules'] = $version['creator']['src'];
+                                    unset($version['creator']['src']);
                                 }
                             }
                         }
                     }
                 }
-                return array_merge($acc, $latestRuntimes);
-            }, []);
-
-            $this->returnJson($result);
-        } catch (PortableElementException $e) {
-            $this->returnJson($e->getMessage(), 500);
-        }
+            }
+            return array_merge($acc, $latestRuntimes);
+        }, []);
     }
 
     protected function getRegistries()

--- a/test/integration/PciLoaderTest.php
+++ b/test/integration/PciLoaderTest.php
@@ -82,7 +82,7 @@ class PciLoaderTest extends TestCase
                     'typeIdentifier' => 'entryCodeInteraction',
                     'version' => '1.2.0',
                     'runtime' => [
-                        'hook' => 'https:\/\/backoffice.ngs.test\/tao\/File\/accessFile\/NjdiZGJlZmY3NTg2ZiBJTVNQQ0kvZDEzMmNmN2ZjY2E3ZjRkMzczNzg0NDE5NDM3YTBmNWE=\/runtime\/entryCode.min.js',
+                        'hook' => '\/\/runtime\/entryCode.min.js',
                         'modules' => [
                             'entryCodeInteraction\/runtime\/entryCode.min' => [
                                 'runtime\/entryCode.min.js'

--- a/test/integration/PciLoaderTest.php
+++ b/test/integration/PciLoaderTest.php
@@ -1,0 +1,238 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk Street, # 960789, Boston, MA 02196, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\qtiItemPci\test\integration;
+
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\oatbox\service\ServiceManager;
+use oat\qtiItemPci\controller\PciLoader;
+use oat\qtiItemPci\model\portableElement\storage\PciRegistry;
+use oat\taoQtiItem\model\portableElement\exception\PortableElementException;
+
+class PciLoaderTest extends TestCase
+{
+    /**
+     * @var MockObject
+     */
+    private $pciRegistryMock;
+
+    /**
+     * @var MockObject
+     */
+    private $imsRegistryMock;
+
+    /**
+     * @var ServiceManager
+     */
+    private $previousServiceManager;
+
+    /**
+     * @throws \common_ext_ExtensionException
+     */
+    public function setUp(): void
+    {
+        $this->previousServiceManager = ServiceManager::getServiceManager();
+
+        // Test data for TAO PCI
+        $pciTestData = [
+            'likertScaleInteraction' => [
+                [
+                    'model' => 'PCI',
+                    'typeIdentifier' => 'likertScaleInteraction',
+                    "version" => "1.2.0",
+                    'runtime' => [
+                        'hook' => 'dist/likertScale/runtime/likertScale.min.js',
+                        'modules' => [
+                            'likertScale' => ['dist/likertScale/runtime/likertScale.min.js']
+                        ],
+                    ],
+                    'creator' => [
+                        'hook' => 'dist/likertScale/creator/likertScale.min.js',
+                        'modules' => ['dist/likertScale/creator/likertScale.min.js'],
+                        'icon' => 'dist/likertScale/creator/img/icon.png'
+                    ]
+                ]
+            ]
+        ];
+
+        // Test data for IMS PCI
+        $imsTestData = [
+            'entryCodeInteraction' => [
+                [
+                    'model' => 'IMSPCI',
+                    'typeIdentifier' => 'entryCodeInteraction',
+                    'version' => '1.2.0',
+                    'runtime' => [
+                        'hook' => 'https:\/\/backoffice.ngs.test\/tao\/File\/accessFile\/NjdiZGJlZmY3NTg2ZiBJTVNQQ0kvZDEzMmNmN2ZjY2E3ZjRkMzczNzg0NDE5NDM3YTBmNWE=\/runtime\/entryCode.min.js',
+                        'modules' => [
+                            'entryCodeInteraction\/runtime\/entryCode.min' => [
+                                'runtime\/entryCode.min.js'
+                            ]
+                        ]
+                    ],
+                    'creator' => [
+                        'icon' => 'entryCodeInteraction\/icon.svg',
+                        'hook' => 'entryCodeInteraction\/imsPciCreator.min.js',
+                        'src' => [
+                            'entryCodeInteraction\/imsPciCreator.js'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->pciRegistryMock = $this->createMock(PciRegistry::class);
+        $this->pciRegistryMock
+            ->method('getLatestRuntimes')
+            ->willReturn($pciTestData);
+
+        $this->imsRegistryMock = $this->createMock(PciRegistry::class);
+        $this->imsRegistryMock
+            ->method('getLatestRuntimes')
+            ->willReturn($imsTestData);
+
+        $extensionMock = $this->createMock(\common_ext_Extension::class);
+        $extensionMock
+            ->method('getConfig')
+            ->with('debug_portable_element')
+            ->willReturn(null);
+
+        $extensionsManagerMock = $this->createMock(\common_ext_ExtensionsManager::class);
+        $extensionsManagerMock
+            ->method('getExtensionById')
+            ->with('taoQtiItem')
+            ->willReturn($extensionMock);
+
+        ServiceManager::setServiceManager($this->traitGetServiceManagerMock([
+            \common_ext_ExtensionsManager::class => $extensionsManagerMock,
+        ]));
+    }
+
+    protected function tearDown(): void
+    {
+        ServiceManager::setServiceManager($this->previousServiceManager);
+        parent::tearDown();
+    }
+
+    /**
+     * Note: the inner logic modifying the PCI structures when debug_portable_element is set is not tested.
+     */
+    public function testLoad()
+    {
+        $registries = [$this->pciRegistryMock, $this->imsRegistryMock];
+        $pciLoader = new PciLoaderForTest($registries);
+        $pciLoader->load();
+
+        $response = $pciLoader->getLastJsonResponse();
+        $statusCode = $pciLoader->getLastJsonStatusCode();
+
+        $this->assertIsArray($response);
+        $this->assertArrayHasKey('likertScaleInteraction', $response);
+        $this->assertArrayHasKey('entryCodeInteraction', $response);
+
+        $this->assertArrayHasKey('runtime', $response['likertScaleInteraction'][0]);
+        $this->assertArrayHasKey('creator', $response['likertScaleInteraction'][0]);
+        $this->assertArrayHasKey('runtime', $response['entryCodeInteraction'][0]);
+        $this->assertArrayHasKey('creator', $response['entryCodeInteraction'][0]);
+
+        $this->assertEquals(200, $statusCode);
+    }
+
+    public function testLoadError()
+    {
+        $exceptionMessage = 'Upstream registry failure';
+        $failingRegistry = $this->createMock(PciRegistry::class);
+        $failingRegistry
+            ->method('getLatestRuntimes')
+            ->willThrowException(new PortableElementException($exceptionMessage));
+
+        $pciLoader = new PciLoaderForTest([$failingRegistry]);
+        $pciLoader->load();
+
+        $this->assertEquals($exceptionMessage, $pciLoader->getLastJsonResponse());
+        $this->assertEquals(500, $pciLoader->getLastJsonStatusCode());
+    }
+
+    public function testGetLatestPciRuntimes()
+    {
+        $registries = [$this->pciRegistryMock, $this->imsRegistryMock];
+        $pciLoader = new PciLoaderForTest($registries);
+        $result = $pciLoader->getLatestPciRuntimes();
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('likertScaleInteraction', $result);
+        $this->assertArrayHasKey('entryCodeInteraction', $result);
+
+        $response = $pciLoader->getLastJsonResponse();
+        $statusCode = $pciLoader->getLastJsonStatusCode();
+
+        $this->assertEquals(null, $response);
+        $this->assertEquals(null, $statusCode);
+    }
+}
+
+class PciLoaderForTest extends PciLoader
+{
+    /**
+     * @var array
+     */
+    private $registries;
+
+    /**
+     * @var array|null
+     */
+    private $lastJsonResponse;
+
+    /**
+     * @var int|null
+     */
+    private $lastJsonStatusCode;
+
+    public function __construct(array $registries = [])
+    {
+        parent::__construct();
+        $this->registries = $registries;
+        $this->lastJsonResponse = null;
+        $this->lastJsonStatusCode = null;
+    }
+
+    protected function getRegistries()
+    {
+        return $this->registries ?: parent::getRegistries();
+    }
+
+    public function returnJson($response, $statusCode = 200)
+    {
+        $this->lastJsonResponse = $response;
+        $this->lastJsonStatusCode = $statusCode;
+    }
+
+    public function getLastJsonResponse()
+    {
+        return $this->lastJsonResponse;
+    }
+
+    public function getLastJsonStatusCode()
+    {
+        return $this->lastJsonStatusCode;
+    }
+}

--- a/test/integration/PciLoaderTest.php
+++ b/test/integration/PciLoaderTest.php
@@ -19,8 +19,13 @@
  *
  */
 
+declare(strict_types=1);
+
 namespace oat\qtiItemPci\test\integration;
 
+use common_ext_Extension;
+use common_ext_ExtensionException;
+use common_ext_ExtensionsManager;
 use oat\generis\test\MockObject;
 use oat\generis\test\TestCase;
 use oat\oatbox\service\ServiceManager;
@@ -46,7 +51,7 @@ class PciLoaderTest extends TestCase
     private $previousServiceManager;
 
     /**
-     * @throws \common_ext_ExtensionException
+     * @throws common_ext_ExtensionException
      */
     public function setUp(): void
     {
@@ -110,20 +115,20 @@ class PciLoaderTest extends TestCase
             ->method('getLatestRuntimes')
             ->willReturn($imsTestData);
 
-        $extensionMock = $this->createMock(\common_ext_Extension::class);
+        $extensionMock = $this->createMock(common_ext_Extension::class);
         $extensionMock
             ->method('getConfig')
             ->with('debug_portable_element')
             ->willReturn(null);
 
-        $extensionsManagerMock = $this->createMock(\common_ext_ExtensionsManager::class);
+        $extensionsManagerMock = $this->createMock(common_ext_ExtensionsManager::class);
         $extensionsManagerMock
             ->method('getExtensionById')
             ->with('taoQtiItem')
             ->willReturn($extensionMock);
 
         ServiceManager::setServiceManager($this->traitGetServiceManagerMock([
-            \common_ext_ExtensionsManager::class => $extensionsManagerMock,
+            common_ext_ExtensionsManager::class => $extensionsManagerMock,
         ]));
     }
 


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/RFE-1512
https://oat-sa.atlassian.net/browse/TR-6795

For use with https://github.com/oat-sa/extension-tao-testqti-previewer/pull/243
PCIs can now be fetched from registry either by HTTP call or by direct PHP call.
Not sure if this will be the final solution, but it seems a useful intermediate step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Backend reorganized so runtime data is computed by a dedicated helper and responses are emitted from a single exit point, clarifying flow and tightening error boundaries for more reliable responses.

* **Tests**
  * Added integration tests validating successful runtime aggregation across registries, correct error propagation and status codes on failures, and isolated helper behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->